### PR TITLE
remove become from include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,7 +65,6 @@
 - name: Zookeeper | Include tasks
   include_tasks: zookeeper.yml
   when: inventory_hostname in zookeeper_group
-  become: yes
   tags:
     - service
 
@@ -78,7 +77,6 @@
     mode: 0600
 
 - name: Kafka | Including tasks
-  become: yes
   include_tasks: "kafka.yml"
   when: inventory_hostname in kafka_group
   tags:


### PR DESCRIPTION
I've havn't seen it yesterday, sorry for that

```
ERROR! 'become' is not a valid attribute for a TaskInclude

The error appears to be in '/root/.ansible/roles/macunha1.confluent-kafka/tasks/main.yml': line 65, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- name: Zookeeper | Include tasks
  ^ here
```