### PR TITLE
Ensure we have spaces surrounding each parameter

### DIFF
--- a/tasks/configure-topics.yml
+++ b/tasks/configure-topics.yml
@@ -20,6 +20,10 @@
     --create {% for parameter in kafka_params %} {{ parameter }} {% endfor %}
     --topic {{ item }}
   run_once: yes
+  register: topic_output
+  failed_when:
+    - topic_output.rc != 0
+    - "'already exists.' not in topic_output.stdout"
   changed_when: no
   with_items: "{{ topics }}"
   tags:

--- a/tasks/configure-topics.yml
+++ b/tasks/configure-topics.yml
@@ -2,7 +2,7 @@
   set_fact:
     kafka_params:
       - "--replication-factor {{ default_replication_factor }}"
-      - "--partitions {{ groups['kafka'] | length }} "
+      - "--partitions {{ groups['kafka'] | length }}"
   tags:
     - create
 
@@ -17,7 +17,7 @@
   command: >
     {{ kafka_bins }}/kafka-topics
     --zookeeper localhost:2181
-    --create {% for parameter in kafka_params %}{{ parameter }}{% endfor %}
+    --create {% for parameter in kafka_params %} {{ parameter }} {% endfor %}
     --topic {{ item }}
   run_once: yes
   changed_when: no


### PR DESCRIPTION
We had an situation where we were unable to create topics as the command was being created incorrectly

```bash
"cmd": ["/opt/confluent-5.4.0/bin/kafka-topics", "--zookeeper", "localhost:2181", "--create", "--replication-factor", "1--partitions", "2", "--topic", "test-topic-001"]
```

This minor changes forces a space before and after each parameter so that we don't munge the command creation