### PR TITLE
Split directories and download into separate files

### DIFF
--- a/tasks/directories.yaml
+++ b/tasks/directories.yaml
@@ -1,0 +1,14 @@
+---
+- name: Installation | Create configuration directory
+  file:
+    path: "{{ conf_dest }}"
+    state: directory
+    force: yes
+
+- name: Installation | Change configuration directory ownership
+  file:
+    path: "{{ conf_dest }}"
+    owner: kafka
+    group: "{{ kafka_system_users.group }}"
+    force: yes
+  when: kafka_system_users.enabled

--- a/tasks/download.yaml
+++ b/tasks/download.yaml
@@ -1,0 +1,51 @@
+---
+- name: Confluent | Check if there's an unarchived package
+  stat:
+    path: "{{ dst_path }}/confluent-{{ confluent_version }}"
+  register: unarchived_confluent_package
+  tags:
+    - installation
+
+- block: # Try to download the Confluent package on the host directly from the internet
+    - name: Confluent | Download
+      get_url:
+        url: "{{ confluent_url }}"
+        dest: "{{ dst_path }}"
+        force: yes
+
+  rescue: # If it fails (e.g. due to network limitations or firewall), download it locally and then copy
+    - name: Confluent | Download locally
+      get_url:
+        url: "{{ confluent_url }}"
+        dest: "{{ local_path }}"
+        force: yes
+      connection: local
+      become: no
+      run_once: yes
+
+    - name: Confluent | Copy local package to hosts
+      copy:
+        src: "/tmp/{{ confluent_distribution }}-{{ confluent_version }}-{{ scala_version }}.tar.gz"
+        dest: "{{ dst_path }}/{{ confluent_distribution }}-{{ confluent_version }}-{{ scala_version }}.tar.gz"
+
+  always:
+    - name: Confluent | Unarchive package
+      unarchive:
+        src: "{{ dst_path }}/{{ confluent_distribution }}-{{ confluent_version }}-{{ scala_version }}.tar.gz"
+        dest: "{{ dst_path }}"
+        remote_src: yes
+
+    - name: System Users | Change unarchived package ownership
+      file:
+        path: "{{ dst_path }}"
+        mode: 0775
+        owner: kafka
+        group: "{{ kafka_system_users.group }}"
+      when: kafka_system_users.enabled
+
+    - name: Confluent | Remove archived package
+      file:
+        path: "{{ dst_path }}/{{ confluent_distribution }}-{{ confluent_version }}-{{ scala_version }}.tar.gz"
+        state: absent
+
+  when: not unarchived_confluent_package.stat.exists

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -12,75 +12,14 @@
   tags:
     - installation
 
-- name: Confluent | Check if there's an unarchived package
-  stat:
-    path: "{{ dst_path }}/confluent-{{ confluent_version }}"
-  register: unarchived_confluent_package
-  tags:
-    - installation
-
-- block: # Try to download the Confluent package on the host directly from the internet
-    - name: Confluent | Download
-      get_url:
-        url: "{{ confluent_url }}"
-        dest: "{{ dst_path }}"
-        force: yes
-
-  rescue: # If it fails (e.g. due to network limitations or firewall), download it locally and then copy
-    - name: Confluent | Download locally
-      get_url:
-        url: "{{ confluent_url }}"
-        dest: "{{ local_path }}"
-        force: yes
-      connection: local
-      become: no
-      run_once: yes
-
-    - name: Confluent | Copy local package to hosts
-      copy:
-        src: "/tmp/{{ confluent_distribution }}-{{ confluent_version }}-{{ scala_version }}.tar.gz"
-        dest: "{{ dst_path }}/{{ confluent_distribution }}-{{ confluent_version }}-{{ scala_version }}.tar.gz"
-
-  always:
-    - name: Confluent | Unarchive package
-      unarchive:
-        src: "{{ dst_path }}/{{ confluent_distribution }}-{{ confluent_version }}-{{ scala_version }}.tar.gz"
-        dest: "{{ dst_path }}"
-        remote_src: yes
-
-    - name: System Users | Change unarchived package ownership
-      file:
-        path: "{{ dst_path }}"
-        mode: 0775
-        owner: kafka
-        group: "{{ kafka_system_users.group }}"
-      when: kafka_system_users.enabled
-
-    - name: Confluent | Remove archived package
-      file:
-        path: "{{ dst_path }}/{{ confluent_distribution }}-{{ confluent_version }}-{{ scala_version }}.tar.gz"
-        state: absent
-
-  when: not unarchived_confluent_package.stat.exists
+- name: Installation | Download binaries if needed
+  import_tasks: download.yaml
   tags:
     - download
     - installation
 
-- name: Configuration | Create directory
-  file:
-    path: "{{ conf_dest }}"
-    state: directory
-    force: yes
-  tags:
-    - installation
-
-- name: Configuration | Change directory ownership
-  file:
-    path: "{{ conf_dest }}"
-    owner: kafka
-    group: "{{ kafka_system_users.group }}"
-    force: yes
-  when: kafka_system_users.enabled
+- name: Installation | Create needed directories
+  import_tasks: directories.yaml
   tags:
     - installation
 


### PR DESCRIPTION
To make this easier to run on vm builds I have split out the download and configuration directory tasks into their own files.

It makes the main.yaml file cleaner and easier to read and keeps separate bits of logic independant