### PR TITLE
Service user

### DIFF
--- a/tasks/directories.yaml
+++ b/tasks/directories.yaml
@@ -8,7 +8,7 @@
 - name: Installation | Change configuration directory ownership
   file:
     path: "{{ conf_dest }}"
-    owner: kafka
+    owner: "{{ confluent_services | first }}"
     group: "{{ kafka_system_users.group }}"
     force: yes
   when: kafka_system_users.enabled

--- a/tasks/download.yaml
+++ b/tasks/download.yaml
@@ -39,7 +39,7 @@
       file:
         path: "{{ dst_path }}"
         mode: 0775
-        owner: kafka
+        owner: "{{ confluent_services | first }}"
         group: "{{ kafka_system_users.group }}"
       when: kafka_system_users.enabled
 

--- a/tasks/kafka.yaml
+++ b/tasks/kafka.yaml
@@ -7,7 +7,7 @@
 - name: System Users | Change config file ownership
   file:
     path: "{{ conf_dest }}/kafka.properties"
-    owner: kafka
+    owner: "{{ confluent_services | first }}"
     group: "{{ kafka_system_users.group }}"
   when: kafka_system_users.enabled
 

--- a/tasks/kafka.yaml
+++ b/tasks/kafka.yaml
@@ -7,7 +7,7 @@
 - name: System Users | Change config file ownership
   file:
     path: "{{ conf_dest }}/kafka.properties"
-    owner: "{{ confluent_services | first }}"
+    owner: "kafka"
     group: "{{ kafka_system_users.group }}"
   when: kafka_system_users.enabled
 

--- a/tasks/logs.yaml
+++ b/tasks/logs.yaml
@@ -14,7 +14,7 @@
     path: "{{ log_basepath }}/{{ item }}"
     state: directory
     mode: 0751
-    owner: kafka
+    owner: "{{ confluent_services | first }}"
     group: "{{ kafka_system_users.group }}"
   with_items: "{{ confluent_services }}"
   when: kafka_system_users.enabled

--- a/tasks/security.yaml
+++ b/tasks/security.yaml
@@ -8,7 +8,7 @@
   file:
     path: "{{ ssl.path }}"
     state: directory
-    owner: kafka
+    owner: "{{ confluent_services | first }}"
     group: "{{ kafka_system_users.group }}"
     mode: 0600
   when: kafka_system_users.enabled
@@ -22,7 +22,7 @@
 - name: System Users | Change certs and keys ownership
   file:
     path: "{{ ssl.path }}"
-    owner: kafka
+    owner: "{{ confluent_services | first }}"
     group: "{{ kafka_system_users.group }}"
     mode: 0600
   with_items: "{{ jkstores }}"
@@ -39,7 +39,7 @@
 - name: System Users | Change services ownership
   file:
     path: "{{ conf_dest }}/{{ item }}"
-    owner: kafka
+    owner: "{{ confluent_services | first }}"
     group: "{{ kafka_system_users.group }}"
     mode: 0644
   with_items: "{{ templates }}"


### PR DESCRIPTION
If we are running zookeeper we do not necessarily want the kafka user created, likewise if we are running kafka we don't want the zookeeper user created. We already have the ability to specify users via the `confluent_services` list however some tasks assume the existence of the `kafka` user which is not always correct

I propose for these tasks below we use the first confluent_services user defined so that if we do not have the assumed user the tasks will not fail and set permissions based on the service user created first