### PR TITLE
Update kafka.properties configuration template

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -63,7 +63,7 @@ ion_timeout_ms: 6000
 confluent_support_metrics_enable: yes
 confluent_support_customer_id: "anonymous"
 auto_create_topics: no
-default_replication_factor: "{{ [ kafka_group | length, 3 ] | min }}"
+default_replication_factor: 1
 offsets_replication_factor: "{{ [ kafka_group | length, 3 ] | min }}"
 min_insync_replicas: 1
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -63,7 +63,10 @@ ion_timeout_ms: 6000
 confluent_support_metrics_enable: yes
 confluent_support_customer_id: "anonymous"
 auto_create_topics: no
-default_replication_factor: "{{ kafka_group | length | root | int }}"
+default_replication_factor: "{{ [ kafka_group | length, 3 ] | min }}"
+offsets_replication_factor: "{{ [ kafka_group | length, 3 ] | min }}"
+min_insync_replicas: 1
+
 
 ssl:
   path: /var/private/ssl

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -67,7 +67,6 @@ default_replication_factor: "{{ [ kafka_group | length, 3 ] | min }}"
 offsets_replication_factor: "{{ [ kafka_group | length, 3 ] | min }}"
 min_insync_replicas: 1
 
-
 ssl:
   path: /var/private/ssl
 

--- a/templates/kafka.properties.j2
+++ b/templates/kafka.properties.j2
@@ -14,7 +14,9 @@
 delete.topic.enable={{ delete_topic_enable }}
 reserved.broker.max.id={{ reserved_broker_max }}
 auto.create.topics.enable={{ auto_create_topics }}
-offsets.topic.replication.factor={{ default_replication_factor }}
+offsets.topic.replication.factor={{ offsets_replication_factor }}
+default.replication.factor={{ default_replication_factor }}
+min.insync.replicas={{ min_insync_replicas }}
 
 ############################# Socket Server Settings #############################
 


### PR DESCRIPTION
Added the following configuration parameters to the kafka.properties template:
- **default.replication.factor** and **min.insync.replicas** set to 1 (as defined in the confluent documentation)
- **offsets.replication.factor** set to the minimum value between the number of brokers and 3 (default value in the confluent documentation)
In this way we can override the default values with new values.
We can also be sure that replication factor for the "__consumer_offsets" will be at least 3 when we have more than 3 brokers and it will be the number of brokers when they are less than 3