### PR TITLE
Add Number of processes limit service configuration and Fix bug in vars declaration

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -77,7 +77,7 @@ local:
   files: ../files
 
 kafka_file_descriptor_limit: 100000
-kafka_noproc_limit: 65536
+kafka_nproc_limit: 65536
 
 kafka_env_file: "{{ confluent_kafka_env_file_path }}/kafka-env.sh"
 
@@ -115,7 +115,7 @@ zookeeper_init_limit: 5
 zookeeper_sync_limit: 3
 zookeeper_connection_timeout: 6000
 zookeeper_file_descriptor_limit: 100000
-zookeeper_noproc_limit: 65536
+zookeeper_nproc_limit: 65536
 zookeeper_env_file: "{{ confluent_kafka_env_file_path }}/zookeeper-env.sh"
 zookeeper_init_memory_heapsize_with_units: 512M
 zookeeper_max_memory_heapsize_with_units: >-
@@ -152,7 +152,7 @@ kafka_services:
     state: "started"
     enabled: yes
     limit_nofile: "{{ kafka_file_descriptor_limit }}"
-    limit_nproc: "{{ kafka_noproc_limit }}"
+    limit_nproc: "{{ kafka_nproc_limit }}"
     environment_file: "{{ kafka_env_file }}"
 
   kafka-rest:
@@ -180,7 +180,7 @@ zookeeper_services:
     state: "started"
     enabled: yes
     limit_nofile: "{{ zookeeper_file_descriptor_limit }}"
-    limit_nproc: "{{ zookeeper_noproc_limit }}"
+    limit_nproc: "{{ zookeeper_nproc_limit }}"
     environment_file: "{{ zookeeper_env_file }}"
 
 # default_kafka_topics:

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -77,6 +77,8 @@ local:
   files: ../files
 
 kafka_file_descriptor_limit: 100000
+kafka_noproc_limit: 65536
+
 kafka_env_file: "{{ confluent_kafka_env_file_path }}/kafka-env.sh"
 
 kafka_init_memory_heapsize_with_units: 1G
@@ -113,6 +115,7 @@ zookeeper_init_limit: 5
 zookeeper_sync_limit: 3
 zookeeper_connection_timeout: 6000
 zookeeper_file_descriptor_limit: 100000
+zookeeper_noproc_limit: 65536
 zookeeper_env_file: "{{ confluent_kafka_env_file_path }}/zookeeper-env.sh"
 zookeeper_init_memory_heapsize_with_units: 512M
 zookeeper_max_memory_heapsize_with_units: >-
@@ -149,6 +152,7 @@ kafka_services:
     state: "started"
     enabled: yes
     limit_nofile: "{{ kafka_file_descriptor_limit }}"
+    limit_nproc: "{{ kafka_noproc_limit }}"
     environment_file: "{{ kafka_env_file }}"
 
   kafka-rest:
@@ -176,6 +180,7 @@ zookeeper_services:
     state: "started"
     enabled: yes
     limit_nofile: "{{ zookeeper_file_descriptor_limit }}"
+    limit_nproc: "{{ zookeeper_noproc_limit }}"
     environment_file: "{{ zookeeper_env_file }}"
 
 # default_kafka_topics:

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -81,9 +81,9 @@ kafka_env_file: "{{ confluent_kafka_env_file_path }}/kafka-env.sh"
 
 kafka_init_memory_heapsize_with_units: 1G
 
-kafka_max_memory_heapsize_with_units: >
-  "{{ ((ansible_memtotal_mb/1024) | root | round | int | string ) + 'G' 
-  if ((ansible_memtotal_mb/1024) | root | round | int)> 1 else '1G' }}"
+kafka_max_memory_heapsize_with_units: >-
+  {{ ((ansible_memtotal_mb/1024) | root | round | int | string ) + 'G'
+  if ((ansible_memtotal_mb/1024) | root | round | int)> 1 else '1G' }}
 
 ## Kafka SSL Vars
 kafka_security:
@@ -115,9 +115,9 @@ zookeeper_connection_timeout: 6000
 zookeeper_file_descriptor_limit: 100000
 zookeeper_env_file: "{{ confluent_kafka_env_file_path }}/zookeeper-env.sh"
 zookeeper_init_memory_heapsize_with_units: 512M
-zookeeper_max_memory_heapsize_with_units: >
-  "{{ ((ansible_memtotal_mb/1024) | root | round | int | string ) + 'G' 
-  if ((ansible_memtotal_mb/1024) | root | round | int)> 1 else '512M' }}"
+zookeeper_max_memory_heapsize_with_units: >-
+  {{ ((ansible_memtotal_mb/1024) | root | round | int | string ) + 'G'
+  if ((ansible_memtotal_mb/1024) | root | round | int)> 1 else '512M' }}
 
 # Zookeeper Garbage Collection Logging
 zookeeper_gc_logger_enabled: true
@@ -125,14 +125,14 @@ zookeeper_gc_logger_name: "{{ log4j_log_dir }}/zookeeper-gc.log"
 zookeeper_gc_logger_enable_opts: "-verbose:gc -Xloggc:{{ zookeeper_gc_logger_name }}"
 zookeeper_gc_logger_number_files: 10
 zookeeper_gc_logger_max_size: 10M
-zookeeper_gc_logger_rotation_opts: >
-  "-XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles={{ zookeeper_gc_logger_number_files }}
-   -XX:GCLogFileSize={{ zookeeper_gc_logger_max_size }}"
+zookeeper_gc_logger_rotation_opts: >-
+  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles={{ zookeeper_gc_logger_number_files }}
+  -XX:GCLogFileSize={{ zookeeper_gc_logger_max_size }}
 zookeeper_gc_logger_format_opts: "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps"
-zookeeper_gc_logger_enabled_opts: > 
-  "{{ zookeeper_gc_logger_enable_opts }} 
-  {{ zookeeper_gc_logger_rotation_opts }} 
-  {{ zookeeper_gc_logger_format_opts }}"
+zookeeper_gc_logger_enabled_opts: >-
+  {{ zookeeper_gc_logger_enable_opts }}
+  {{ zookeeper_gc_logger_rotation_opts }}
+  {{ zookeeper_gc_logger_format_opts }}
 zookeeper_gc_logger_disabled_opts: "-Dnogclog"
 
 ## Services

--- a/templates/systemd.service.j2
+++ b/templates/systemd.service.j2
@@ -19,6 +19,9 @@ StartLimitBurst=0
 {% if item.value.limit_nofile is defined %}
 LimitNOFILE={{ item.value.limit_nofile }}
 {% endif %}
+{% if item.value.limit_nproc is defined %}
+LimitNPROC={{ item.value.limit_nproc }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hi! Another pr! :)
- Add a configuration to define the Number of processes limit. I set the default value to 65536 as suggest by Cloudera documentation. It seems that the default value for Number of processes is too small
- Bug fix in vars declaration: I did a last minute commit in the previous pr to change the declaration of 4 vars to pass the circleci test (var length < 120). I found out today that the build vars were wrong with that change, so I fix them
